### PR TITLE
Simplfy brew install into one command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ A fast and lightweight utility to easily find paths to values in large JSON file
 ## Installation
 
 ```sh
-brew tap wtfox/tap
-
-brew install jsonfind
+brew install wtfox/tap/jsonfind
 ```
 
 ---


### PR DESCRIPTION
You can install formulas from taps with one command.

Works just fine:

```terminal
 $ brew install wtfox/tap/jsonfind
==> Tapping wtfox/tap
Cloning into '/usr/local/Homebrew/Library/Taps/wtfox/homebrew-tap'...
remote: Enumerating objects: 51, done.
remote: Counting objects: 100% (51/51), done.
remote: Compressing objects: 100% (39/39), done.
remote: Total 51 (delta 8), reused 11 (delta 0), pack-reused 0
Receiving objects: 100% (51/51), 9.11 KiB | 490.00 KiB/s, done.
Resolving deltas: 100% (8/8), done.
Tapped 1 formula (15 files, 19.2KB).
==> Downloading https://github.com/WTFox/jsonfind/releases/download/v1.1.0/jsonfind_1.1.0_Darwin_x86_64.tar.gz
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/273334301/5c31853c-8a28-4e1a-9c0d-b8978d31302d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-A
######################################################################## 100.0%
==> Installing jsonfind from wtfox/tap
🍺  /usr/local/Cellar/jsonfind/1.1.0: 6 files, 3.1MB, built in 3 seconds
==> Running `brew cleanup jsonfind`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```